### PR TITLE
Added types definitions in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
 	"exports": {
 		".": {
 			"import": "./dist/use-lanyard.esm-bundler.js",
-			"require": "./dist/use-lanyard.cjs.js"
+			"require": "./dist/use-lanyard.cjs.js",
+			"types": "./dist/use-lanyard.d.ts"
 		},
 		"./package.json": "./package.json"
 	},


### PR DESCRIPTION
Hi 😄 , I'm writing this PR because I've encountered a typing problem in my vue js project with your project.

My vue compiler couldn't find the typing on its own, so I added an export to the typing file in your package json.

> error TS7016: Could not find a declaration file for module '@leonardssh/use-lanyard'. '.../node_modules/.pnpm/@leonardssh+use-lanyard@1.0.4_vue@3.4.31/node_modules/@leonardssh/use-lanyard/dist/use-lanyard.esm-bundler.js' implicitly has an 'any' type.
>   There are types at '.../node_modules/@leonardssh/use-lanyard/dist/use-lanyard.d.ts', but this result could not be resolved when respecting package.json "exports". The '@leonardssh/use-lanyard' library may need to update its package.json or typings.

Have a nice day 👍 